### PR TITLE
remove rounding of saved display brightness

### DIFF
--- a/src/service-app/classes/DisplayBacklightWorker.ts
+++ b/src/service-app/classes/DisplayBacklightWorker.ts
@@ -110,7 +110,7 @@ export class DisplayBacklightWorker extends DaemonWorker {
                 if (value === 0) {
                     this.tccd.logLine('DisplayBacklightWorker: Refused to save display brightness 0 from ' + controller.driver);
                 } else {
-                    this.tccd.autosave.displayBrightness = Math.round((value * 100) / maxBrightness);
+                    this.tccd.autosave.displayBrightness = (value * 100) / maxBrightness;
                     this.tccd.logLine('DisplayBacklightWorker: Save display brightness '
                         + this.tccd.autosave.displayBrightness + '% (' + value + ') on exit');
                 }


### PR DESCRIPTION
This prevents rounding from values < 0.5% to 0% (blacklight turns off).

Sometimes i am working with 0.1% brightness and the backlight turns off after suspend or profile change, which is annoying.