### PR TITLE
libudev-dev is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ tuxedo-control-center
 
 ## Development setup
 
-1. Install git, nodejs, gcc, g++, make \
+1. Install git, nodejs, gcc, g++, make, libudev-dev \
    Ex (deb):
    ```
    curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
 
-   sudo apt install -y git gcc g++ make nodejs npm
+   sudo apt install -y git gcc g++ make nodejs npm libudev-dev
    ```
 2. Clone & install libraries
     ```


### PR DESCRIPTION
Without this I got an error message after `npm install`:
`../src/native-lib/tuxedo_io_napi.cc:22:10: fatal error: libudev.h: File or directory not found`