### PR TITLE
Updating README.md with missing packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ tuxedo-control-center
    ```
    curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
 
-   sudo apt install -y git gcc g++ make nodejs npm
+   sudo apt install -y nodejs git gcc g++ make nodejs npm libudev-dev
    ```
 2. Clone & install libraries
     ```


### PR DESCRIPTION
NodeJS needs to be installed as well as libudev-header files later at "npm install". I've added both packages that I needed to run on Ubuntu 20.04.02 LTS.