### PR TITLE
npm already included in nodesource nodejs package

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ tuxedo-control-center
    ```
    curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
 
-   sudo apt install -y git gcc g++ make nodejs npm libudev-dev
+   sudo apt install -y git gcc g++ make nodejs libudev-dev
    ```
 2. Clone & install libraries
     ```


### PR DESCRIPTION
Hi, this really minor fix could help a lot non nodejs people like me by amending current development setup doc section. Trying to install `npm` package will inevitably lead to problems as it overlaps `nodejs` package contents.

HTH, thank you, love you tuxedo :heart: !