### PR TITLE
Changed the regular expression that blocks the service when under Way…

### DIFF
--- a/src/common/classes/XDisplayRefreshRateController.ts
+++ b/src/common/classes/XDisplayRefreshRateController.ts
@@ -33,7 +33,7 @@ export class XDisplayRefreshRateController {
         let result = child_process.execSync(`who`) + "";
 
         // Capturing groups: 1 is user name, 2 can be ignored and 3 is the display variable.
-        var correctLineRegex = /(\w+)\s+(.+\s+)+(\(:.+\))/;
+        var correctLineRegex = /(\w+)(.*)(\(:.+\))/;
 
         var match = result.match(correctLineRegex);
 


### PR DESCRIPTION
It seems the current regular expression to extract the user name and the display id freezes when executed against the output corresponding to a Wayland session.

It relates to this issue: https://github.com/tuxedocomputers/tuxedo-control-center/issues/335