### PR TITLE
do not disconnect all bluetooth devices while scanning

### DIFF
--- a/src/e-app/LCT21001.ts
+++ b/src/e-app/LCT21001.ts
@@ -155,7 +155,7 @@ export class LCT21001 {
             try {
                 blDevice = await this.adapter.getDevice(deviceId);
             } catch (err) {
-                await blDevice.disconnect();
+                console.log("Error getting device: " + err);
                 continue;
             }
             const info = new DeviceInfo();
@@ -164,7 +164,7 @@ export class LCT21001 {
             try {
                 info.rssi = parseInt(await blDevice.getRSSI());
             } catch (err) {
-                await blDevice.disconnect();
+                console.log("Error getting RSSI: " + err);
                 continue;
             }
 
@@ -173,8 +173,6 @@ export class LCT21001 {
             } catch (err) {
                 info.name = '';
             }
-
-            await blDevice.disconnect();
 
             if (info.name.toLowerCase().indexOf('lct21001') !== -1) {
                 deviceInfo.push(info);
@@ -202,9 +200,9 @@ export class LCT21001 {
 
     /**
      * Write to the uart tx characteristic
-     * 
+     *
      * @param buffer `Buffer` of data to write
-     * 
+     *
      * Note: Throws error if not connected
      */
     async writeBuffer(buffer: Buffer) {
@@ -217,9 +215,9 @@ export class LCT21001 {
 
     /**
      * Read from the uart rx characteristic
-     * 
+     *
      * @returns A `Buffer` with the data read
-     * 
+     *
      * Note: Throws error if not connected
      */
     async readBuffer() {
@@ -233,10 +231,10 @@ export class LCT21001 {
     /**
      * Write to the uart tx characteristic and wait for a
      * notification on the uart rx characteristic
-     * 
+     *
      * @param inputBuffer `Buffer` to write to device
      * @returns A `Buffer` with the response
-     * 
+     *
      * Note: Throws error if not connected
      */
     async writeReceive(inputBuffer: Buffer): Promise<Buffer> {
@@ -263,7 +261,7 @@ export class LCT21001 {
 
     /**
      * Write RGB color and state to device
-     * 
+     *
      * @param red Red color 0-255
      * @param green Green color 0-255
      * @param blue Blue color 0-255
@@ -286,7 +284,7 @@ export class LCT21001 {
 
     /**
      * Write fan speed to device
-     * 
+     *
      * @param dutyCyclePercent Fan speed in percent 0-100
      */
     async writeFanMode(dutyCyclePercent: number) {
@@ -302,7 +300,7 @@ export class LCT21001 {
 
     /**
      * Write pump parameters to device
-     * 
+     *
      * @param pumpDutyCyclePercent Duty cycle in percent 0-100
      * @param pumpVoltage See `PumpVoltage` for valid settings
      */
@@ -327,7 +325,7 @@ export class LCT21001 {
 
     /**
      * Read firmware version from device
-     * 
+     *
      * @returns A `Buffer` representing a string describing the firmware version
      */
     async readFwVersion() {

--- a/src/e-app/main.ts
+++ b/src/e-app/main.ts
@@ -147,7 +147,7 @@ app.whenReady().then( async () => {
         tray.state.isAutostartTrayInstalled = isAutostartTrayInstalled();
         tray.create();
     };
-    
+
     tray.events.fnLockClick = (status: boolean) => {
         tray.state.fnLockStatus = !status
         tccDBus.setFnLockStatus(tray.state.fnLockStatus);
@@ -1100,7 +1100,7 @@ const aquarisHandlers = new Map<string, (...args: any[]) => any>()
         aquarisStateExpected.pumpOn = false;
         await updateDeviceState(aquaris, aquarisStateCurrent, aquarisStateExpected);
     })
-    
+
     .set(ClientAPI.prototype.saveState.name, async () => {
         if (await aquarisConnectedDemo()) return;
         await userConfig.set('aquarisSaveState', JSON.stringify(aquarisStateCurrent));


### PR DESCRIPTION
When scanning for the Aquaris my bluetooth devices are disconnected. Upon investigation I found that during the search for the aquaris, all bluetooth devices are enumerated and then disconnected, although the TCC never connects to them. This caused my mouse, keyboard etc to be disconnected. 

This looks to me like a bit overly aggressive as IMO the TCC should not change the state of unrelated devices. 

With these changes, the Aquaris gets found on my system without disrupting any other BT devices. 