### PR TITLE
Update compatibility.service.ts to support Stellaris 17 Gen6

### DIFF
--- a/src/ng-app/app/compatibility.service.ts
+++ b/src/ng-app/app/compatibility.service.ts
@@ -52,12 +52,9 @@ export class CompatibilityService {
                 sysVendor.toLowerCase().includes("tuxedo"));
 
         if (isTuxedo) {
-            if (
-                deviceName !== undefined &&
-                (deviceName === "STELLARIS1XI04" ||
-                    deviceName === "STEPOL1XA04" ||
-                    deviceName === "STELLARIS1XI05")
-            ) {
+            if (isTuxedo) {
+            const validDeviceNames = ["STELLARIS1XI04", "STEPOL1XA04", "STELLARIS1XI05", "STELLARIS17I06"];
+            if (deviceName !== undefined && validDeviceNames.includes(deviceName)) {
                 showAquarisMenu = true;
             } else {
                 showAquarisMenu = false;


### PR DESCRIPTION
Adding support for latest model of Stellaris (17, Gen6, i.e. STELLARIS17I06) and Aquaris
Otherwise, current prod version does not show Aquaris icon at all

I got the model name via:
```
sudo lshw | grep TUXEDO
    product: TUXEDO Stellaris 17 Intel Gen6 (STELLARIS17I06)
```
