### PR TITLE
Show current profile in TCC context menu

### DIFF
--- a/src/e-app/TccTray.ts
+++ b/src/e-app/TccTray.ts
@@ -91,11 +91,14 @@ export class TccTray {
         const contextMenu = Menu.buildFromTemplate([
             { label: 'TUXEDO Control Center', type: 'normal', click: () => this.events.startTCCClick() },
             { label: 'Aquaris control', type: 'normal', click: () => this.events.startAquarisControl(), visible: showAquarisMenu },
+            { type: 'separator' },
             {
                 label: 'Profiles',
                 submenu: profilesSubmenu,
                 visible: this.state.profiles.length > 0
             },
+            { label: this.state.activeProfile.name, type: 'normal', enabled: false },
+            { type: 'separator' },
             {
                     label: 'Tray autostart', type: 'checkbox', checked: this.state.isAutostartTrayInstalled,
                     click: () => this.events.autostartTrayToggle()


### PR DESCRIPTION
There's no 1-click way to check current profile.

* The PR adds disabled menu item under the Profiles submenu.
* Also Profiles submenu and active profile are being separated by separators.