### PR TITLE
Add support for the XDG Base Directory specification

### DIFF
--- a/src/e-app/main.ts
+++ b/src/e-app/main.ts
@@ -36,7 +36,7 @@ const appPath = __dirname.replace('app.asar/', '');
 
 const autostartLocation = path.join(os.homedir(), '.config/autostart');
 const autostartDesktopFilename = 'tuxedo-control-center-tray.desktop';
-const tccConfigDir = path.join(os.homedir(), '.tcc');
+const tccConfigDir = getConfigDirPath();
 const tccStandardConfigFile = path.join(tccConfigDir, 'user.conf');
 const availableLanguages = [
     'en',
@@ -802,6 +802,21 @@ function isFirstStart(): boolean {
     return !userConfigDirExists();
 }
 
+function getConfigDirPath(): string {
+    const homeDir = os.homedir();
+    const homeTccConfigDir = path.join(homeDir, '.tcc');
+
+    const envXdgConfigDir = process.env.XDG_CONFIG_HOME;
+    const customXdgConfigDir = path.join(homeDir, '.config');
+
+    if (fs.existsSync(homeTccConfigDir)) {
+        return homeTccConfigDir;
+    } else {
+        const xdgConfigDirToUse = envXdgConfigDir || customXdgConfigDir;
+        return path.join(xdgConfigDirToUse, 'tuxedo-control-center');
+    }
+}
+
 function userConfigDirExists(): boolean {
     try {
         return fs.existsSync(tccConfigDir);
@@ -812,7 +827,7 @@ function userConfigDirExists(): boolean {
 
 function createUserConfigDir(): boolean {
     try {
-        fs.mkdirSync(tccConfigDir);
+        fs.mkdirSync(tccConfigDir, { recursive: true });
         return true;
     } catch (err) {
         return false;


### PR DESCRIPTION
### Motivation 

_(just in case you are not aware of the spec...)_

The [XDG Base Directory specification](https://specifications.freedesktop.org/basedir-spec/latest/) is a wider effort in the Linux community to standarize where applications place their relevant files (whether they are configuration / cache related etc). This helps in decluttering their home folder but also makes tracking their configuration files more easily using their version control system of their choice.

For more please read: https://wiki.archlinux.org/title/XDG_Base_Directory

### Proposal

I took inspiration from [this recently closed PR](https://github.com/tuxedocomputers/tuxedo-control-center/pull/359) and improved upon some areas (mainly addressed the comment that was raised there).

What I am proposing is this:

- If there is already a `~/.tcc/` directory then use that. This keeps backwards compatibility.
- If not, then if there is an `XDG_CONFIG_HOME` environment variable set use `$XDG_CONFIG_HOME/tuxedo-control-center/` as the configuration directory.
- If there is no such environment variable then just use `~/.config/tuxedo-control-center/`

I took the liberty of naming the directory `tuxedo-control-center` as I think it is more readable, but it is obviously up to you!

### Migration steps

- For users that do not care about this, nothing needs to be done
- For users that care about this, they can just manually move the files to the place that they want (`XDG_CONFIG_HOME` or `~/.config`) and just delete the `~/.tcc` directory.


### Disclaimer

These changes have not been tested and my JS/TS knowledge is not amazing. That being said I did run these functions on a node instance so that I am at least sure they do what I think they do.