### PR TITLE
Correct spelling of "prioritize"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,7 +255,7 @@
 ### Added
 - Battery charging options for a number of devices
   - Choose one of three "charging profiles" to influence peak charge and charging time
-  - Choose whether to priorize charging or performance when on USB-C PD
+  - Choose whether to prioritize charging or performance when on USB-C PD
   - For now available through "Settings" => "Battery charging options" (for devices with this feature)
   - Tray shortcut coming soon
 

--- a/src/ng-app/app/charging-settings/charging-settings.component.ts
+++ b/src/ng-app/app/charging-settings/charging-settings.component.ts
@@ -102,11 +102,11 @@ export class ChargingSettingsComponent implements OnInit, OnDestroy {
         this.chargingProfileDescriptions.set('balanced', $localize `:@@chargingProfileBalancedDescription:Reduced charging speed and battery capacity (~90 %) for better battery lifespan.`);
         this.chargingProfileDescriptions.set('stationary', $localize `:@@chargingProfileStationaryDescription:Very significant reduced charging speed and battery capacity (~80 %) for best possible battery lifespan. This is recommended if you use your TUXEDO almost only stationary connected to a wall outlet.`);
 
-        this.chargingPriorityLabels.set('charge_battery', $localize `:@@chargingPriorityChargeBatteryLabel:Priorize battery charging speed`);
-        this.chargingPriorityLabels.set('performance', $localize `:@@chargingPriorityPerformanceLabel:Priorize performance`);
+        this.chargingPriorityLabels.set('charge_battery', $localize `:@@chargingPriorityChargeBatteryLabel:Prioritize battery charging speed`);
+        this.chargingPriorityLabels.set('performance', $localize `:@@chargingPriorityPerformanceLabel:Prioritize performance`);
 
-        this.chargingPriorityDescriptions.set('charge_battery', $localize `:@@chargingPriorityChargeBatteryDescription:Fast battery charging is priorized at the expense of system performance. Once the battery is charged, full performance is available.`);
-        this.chargingPriorityDescriptions.set('performance', $localize `:@@chargingPriorityPerformanceDescription:Performance is priorized over battery charging speed. Under high system load charging speed is reduced for best performance. At low loads full charging speed is available.`);
+        this.chargingPriorityDescriptions.set('charge_battery', $localize `:@@chargingPriorityChargeBatteryDescription:Fast battery charging is prioritized at the expense of system performance. Once the battery is charged, full performance is available.`);
+        this.chargingPriorityDescriptions.set('performance', $localize `:@@chargingPriorityPerformanceDescription:Performance is prioritized over battery charging speed. Under high system load charging speed is reduced for best performance. At low loads full charging speed is available.`);
 
         this.thresholdPresets.set(BatteryThresholdOptions.Balanced, new ThresholdPresets(60, 90));
         this.thresholdPresets.set(BatteryThresholdOptions.Stationary, new ThresholdPresets(40, 80));

--- a/src/ng-app/assets/locale/lang.de.xlf
+++ b/src/ng-app/assets/locale/lang.de.xlf
@@ -2731,7 +2731,7 @@ Handelsregisternummer HRB 27755
         </context-group>
       </trans-unit>
       <trans-unit id="chargingPriorityChargeBatteryLabel" datatype="html">
-        <source>Priorize battery charging speed</source>
+        <source>Prioritize battery charging speed</source>
         <target state="translated">Akku schnell laden</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/ng-app/app/charging-settings/charging-settings.component.ts</context>
@@ -2739,7 +2739,7 @@ Handelsregisternummer HRB 27755
         </context-group>
       </trans-unit>
       <trans-unit id="chargingPriorityPerformanceLabel" datatype="html">
-        <source>Priorize performance</source>
+        <source>Prioritize performance</source>
         <target state="translated">Beste Leistung</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/ng-app/app/charging-settings/charging-settings.component.ts</context>
@@ -2747,7 +2747,7 @@ Handelsregisternummer HRB 27755
         </context-group>
       </trans-unit>
       <trans-unit id="chargingPriorityChargeBatteryDescription" datatype="html">
-        <source>Fast battery charging is priorized at the expense of system performance. Once the battery is charged, full performance is available.</source>
+        <source>Fast battery charging is prioritized at the expense of system performance. Once the battery is charged, full performance is available.</source>
         <target state="translated">Die schnelle Aufladung des Akkus hat Vorrang zulasten der Systemleistung. Sobald der Akku aufgeladen ist, steht die volle Systemleistung zur Verfügung.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/ng-app/app/charging-settings/charging-settings.component.ts</context>
@@ -2755,7 +2755,7 @@ Handelsregisternummer HRB 27755
         </context-group>
       </trans-unit>
       <trans-unit id="chargingPriorityPerformanceDescription" datatype="html">
-        <source>Performance is priorized over battery charging speed. Under high system load charging speed is reduced for best performance. At low loads full charging speed is available.</source>
+        <source>Performance is prioritized over battery charging speed. Under high system load charging speed is reduced for best performance. At low loads full charging speed is available.</source>
         <target state="translated">Die Leistung des PCs hat Vorrang vor der Aufladegeschwindigkeit. Unter hoher Last ist die Ladegeschwindigkeit zugunsten maximaler Leistung verringert; Bei geringer Last steht die volle Ladegeschwindigkeit zur Verfügung.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/ng-app/app/charging-settings/charging-settings.component.ts</context>

--- a/src/ng-app/assets/locale/lang.en.xlf
+++ b/src/ng-app/assets/locale/lang.en.xlf
@@ -2741,32 +2741,32 @@ Commercial register number - Part B of the commercial register - 27755
         </context-group>
       </trans-unit>
       <trans-unit id="chargingPriorityChargeBatteryLabel" datatype="html">
-        <source>Priorize battery charging speed</source>
-        <target state="translated">Priorize battery charging speed</target>
+        <source>Prioritize battery charging speed</source>
+        <target state="translated">Prioritize battery charging speed</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/ng-app/app/charging-settings/charging-settings.component.ts</context>
           <context context-type="linenumber">105</context>
         </context-group>
       </trans-unit>
       <trans-unit id="chargingPriorityPerformanceLabel" datatype="html">
-        <source>Priorize performance</source>
-        <target state="translated">Priorize performance</target>
+        <source>Prioritize performance</source>
+        <target state="translated">Prioritize performance</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/ng-app/app/charging-settings/charging-settings.component.ts</context>
           <context context-type="linenumber">106</context>
         </context-group>
       </trans-unit>
       <trans-unit id="chargingPriorityChargeBatteryDescription" datatype="html">
-        <source>Fast battery charging is priorized at the expense of system performance. Once the battery is charged, full performance is available.</source>
-        <target state="translated">Fast battery charging is priorized at the expense of system performance. Once the battery is charged, full performance is available.</target>
+        <source>Fast battery charging is prioritized at the expense of system performance. Once the battery is charged, full performance is available.</source>
+        <target state="translated">Fast battery charging is prioritized at the expense of system performance. Once the battery is charged, full performance is available.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/ng-app/app/charging-settings/charging-settings.component.ts</context>
           <context context-type="linenumber">108</context>
         </context-group>
       </trans-unit>
       <trans-unit id="chargingPriorityPerformanceDescription" datatype="html">
-        <source>Performance is priorized over battery charging speed. Under high system load charging speed is reduced for best performance. At low loads full charging speed is available.</source>
-        <target state="translated">Performance is priorized over battery charging speed. Under high system load charging speed is reduced for best performance. At low loads full charging speed is available.</target>
+        <source>Performance is prioritized over battery charging speed. Under high system load charging speed is reduced for best performance. At low loads full charging speed is available.</source>
+        <target state="translated">Performance is prioritized over battery charging speed. Under high system load charging speed is reduced for best performance. At low loads full charging speed is available.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/ng-app/app/charging-settings/charging-settings.component.ts</context>
           <context context-type="linenumber">109</context>

--- a/src/ng-app/assets/locale/lang.xlf
+++ b/src/ng-app/assets/locale/lang.xlf
@@ -2386,28 +2386,28 @@ Commercial register number - Part B of the commercial register - 27755
         </context-group>
       </trans-unit>
       <trans-unit id="chargingPriorityChargeBatteryLabel" datatype="html">
-        <source>Priorize battery charging speed</source>
+        <source>Prioritize battery charging speed</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/ng-app/app/charging-settings/charging-settings.component.ts</context>
           <context context-type="linenumber">105</context>
         </context-group>
       </trans-unit>
       <trans-unit id="chargingPriorityPerformanceLabel" datatype="html">
-        <source>Priorize performance</source>
+        <source>Prioritize performance</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/ng-app/app/charging-settings/charging-settings.component.ts</context>
           <context context-type="linenumber">106</context>
         </context-group>
       </trans-unit>
       <trans-unit id="chargingPriorityChargeBatteryDescription" datatype="html">
-        <source>Fast battery charging is priorized at the expense of system performance. Once the battery is charged, full performance is available.</source>
+        <source>Fast battery charging is prioritized at the expense of system performance. Once the battery is charged, full performance is available.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/ng-app/app/charging-settings/charging-settings.component.ts</context>
           <context context-type="linenumber">108</context>
         </context-group>
       </trans-unit>
       <trans-unit id="chargingPriorityPerformanceDescription" datatype="html">
-        <source>Performance is priorized over battery charging speed. Under high system load charging speed is reduced for best performance. At low loads full charging speed is available.</source>
+        <source>Performance is prioritized over battery charging speed. Under high system load charging speed is reduced for best performance. At low loads full charging speed is available.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/ng-app/app/charging-settings/charging-settings.component.ts</context>
           <context context-type="linenumber">109</context>


### PR DESCRIPTION
This PR fixes the incorrect spelling "priorize" to the correct "prioritize" across the entire codebase.

The typo was present in multiple locations, including UI labels, descriptions, and documentation.

- No code logic changes