### PR TITLE
feat: Added Aquaris auto-connect toggle

### DIFF
--- a/src/e-app/AquarisAPI.ts
+++ b/src/e-app/AquarisAPI.ts
@@ -56,6 +56,8 @@ export class ClientAPI {
     public writePumpMode(dutyCyclePercent: number, voltage: PumpVoltage | number) { return this.ipc.invoke(this.apiHandle, [ClientAPI.prototype.writePumpMode.name, dutyCyclePercent, voltage]); }
     public writePumpOff() { return this.ipc.invoke(this.apiHandle, [ClientAPI.prototype.writePumpOff.name]); }
     public saveState() { return this.ipc.invoke(this.apiHandle, [ClientAPI.prototype.saveState.name]); }
+    public getAutoConnect() { return this.ipc.invoke(this.apiHandle, [ClientAPI.prototype.getAutoConnect.name]) as Promise<boolean>; }
+    public setAutoConnect(enabled: boolean) { return this.ipc.invoke(this.apiHandle, [ClientAPI.prototype.setAutoConnect.name, enabled]); }
 }
 
 export function registerAPI (ipcMain: Electron.IpcMain, apiHandle: string, mainsideHandlers: Map<string, (...args: any[]) => any>) {

--- a/src/ng-app/app/aquaris-control/aquaris-control.component.html
+++ b/src/ng-app/app/aquaris-control/aquaris-control.component.html
@@ -45,6 +45,12 @@ along with TUXEDO Control Center.  If not, see <https://www.gnu.org/licenses/>.
             </button>
         </span>
         <button mat-raised-button (click)="connectionToggle()" *ngIf="isConnected && !isConnecting && !isDisconnecting" i18n="@@aqButtonDisconnectLabel">Disconnect</button>
+        <mat-slide-toggle
+            class="auto-reconnect-toggle green-slide-toggle"
+            *ngIf="isConnected && !isConnecting && !isDisconnecting"
+            [formControl]="ctrlAutoConnect"
+            (change)="toggleAutoConnect()"
+            i18n="@@aqAutoReconnectToggleLabel">Auto-reconnect on startup</mat-slide-toggle>
     </mat-card-title>
 
     <div class="aquaris-content">
@@ -193,6 +199,13 @@ along with TUXEDO Control Center.  If not, see <https://www.gnu.org/licenses/>.
 
         <div class="device-list-wrapper" *ngIf="hasBluetooth && !isConnected && !isConnecting && !isDisconnecting && deviceList.length > 0">
             <ng-container i18n="@@aqChooseAquarisText">Please choose your TUXEDO Aquaris and click on the connect button</ng-container>
+            <p class="auto-reconnect-notice" *ngIf="autoConnectEnabled && getAutoConnectTargetDisplay()">
+                <mat-icon>sync</mat-icon>
+                <span i18n="@@aqAutoReconnectNotice">Auto-reconnect is enabled. Will automatically connect to</span>
+                <strong>{{ getAutoConnectTargetDisplay() }}</strong>
+                <span i18n="@@aqAutoReconnectNoticeWhenDetected">when detected.</span>
+                <button mat-stroked-button class="disable-auto-reconnect-button" (click)="disableAutoConnect()" i18n="@@aqDisableAutoReconnectButton">Disable</button>
+            </p>
             <mat-selection-list [formControl]="ctrlDeviceList" [multiple]="false" [hidden]="deviceList.length === 0">
                 <mat-list-option #currentOption *ngFor="let device of deviceList" [value]="device.uuid" (click)="selectDevice(device.uuid)">
                     <mat-icon mat-list-icon *ngIf="device.rssi >= -65">signal_cellular_alt</mat-icon>
@@ -220,6 +233,13 @@ along with TUXEDO Control Center.  If not, see <https://www.gnu.org/licenses/>.
         </div>
 
         <div class="troubleshoot-list" *ngIf="(!isConnected && !isConnecting && !isDisconnecting) && (hasBluetooth && deviceList.length === 0)">
+            <p class="auto-reconnect-notice" *ngIf="autoConnectEnabled && getAutoConnectTargetDisplay()">
+                <mat-icon>sync</mat-icon>
+                <span i18n="@@aqAutoReconnectNotice">Auto-reconnect is enabled. Will automatically connect to</span>
+                <strong>{{ getAutoConnectTargetDisplay() }}</strong>
+                <span i18n="@@aqAutoReconnectNoticeWhenDetected">when detected.</span>
+                <button mat-stroked-button class="disable-auto-reconnect-button" (click)="disableAutoConnect()" i18n="@@aqDisableAutoReconnectButton">Disable</button>
+            </p>
             <p><b i18n="@@aqNoDevicesHeadlineText">TUXEDO Control Center could not find your TUXEDO Aquaris</b></p>
             <p i18n="@@aqNoDevicesVerifyText">Please verify that:</p>
             <ol>

--- a/src/ng-app/app/aquaris-control/aquaris-control.component.scss
+++ b/src/ng-app/app/aquaris-control/aquaris-control.component.scss
@@ -215,3 +215,35 @@
 .try-demo-mode-button {
     margin: 0 10px;
 }
+
+.auto-reconnect-toggle {
+    margin-top: 10px;
+    font-size: 0.8em;
+}
+
+.auto-reconnect-notice {
+    display: flex;
+    flex-flow: row wrap;
+    align-items: center;
+    gap: 5px;
+    margin: 15px 0;
+    padding: 10px 15px;
+    background-color: rgba(100, 209, 113, 0.15);
+    border: 1px solid rgba(100, 209, 113, 0.5);
+    border-radius: 4px;
+    font-size: 0.9em;
+
+    mat-icon {
+        color: rgba(100, 209, 113, 1.0);
+        font-size: 20px;
+        height: 20px;
+        width: 20px;
+    }
+
+    .disable-auto-reconnect-button {
+        margin-left: auto;
+        font-size: 0.85em;
+        line-height: 1.5em;
+        padding: 0 10px;
+    }
+}


### PR DESCRIPTION
Fixes #398 and fixes #437.

This adds a new toggle in the Aquaris section to automatically connect on start if available.

I tried to make this reasonably safe, reminding the user that they need to disconnect in TCC before unplugging the pipes.

Seems to work on mine.
Looking for feedback.

This is my first PR to this codebase, and I'm not super familiar with frontend work generaly.