### PR TITLE
Autoshow dGPU if iGPU is disabled

### DIFF
--- a/src/ng-app/app/cpu-dashboard/cpu-dashboard.component.html
+++ b/src/ng-app/app/cpu-dashboard/cpu-dashboard.component.html
@@ -267,7 +267,7 @@ along with TUXEDO Control Center.  If not, see <https://www.gnu.org/licenses/>.
                 <!-- TABS -->
                 <div class="gauge-tabs"
                     *ngIf="availability.isIGpuAvailable() && availability.isDGpuAvailable() && (primeState === 'on-demand' || primeState === '-1')">
-                    <mat-tab-group mat-align-tabs="center" disablePagination="true">
+                    <mat-tab-group mat-align-tabs="center" disablePagination="true" [selectedIndex]="gpuMonitorTabIndex">
                         <mat-tab label="Power-saving CPU graphics processor (iGPU)" i18n-label="@@primeSelectIGpu">
                             <div class="content-container system-monitor-gauges">
                                 <div class="tcc-gauge" *ngIf="cpuVendor == 'amd'"

--- a/src/ng-app/app/cpu-dashboard/cpu-dashboard.component.ts
+++ b/src/ng-app/app/cpu-dashboard/cpu-dashboard.component.ts
@@ -95,6 +95,8 @@ export class CpuDashboardComponent implements OnInit, OnDestroy {
 
     public primeState: string;
     public primeSelectValues: string[] = ["iGPU", "dGPU", "on-demand", "off"];
+    public gpuMonitorTabIndex: number = 0;
+    private gpuMonitorTabIndexSet: boolean = false;
 
     private dashboardVisibility: boolean;
     public d0MetricsUsage: boolean;
@@ -308,6 +310,13 @@ export class CpuDashboardComponent implements OnInit, OnDestroy {
         this.subscriptions.add(
             this.tccdbus.iGpuInfo.subscribe((iGpuInfo?: IiGpuInfo) => {
                 this.setIGpuValues(iGpuInfo);
+                // Set the default GPU monitor tab once based on whether iGPU has useful data
+                if (!this.gpuMonitorTabIndexSet && iGpuInfo !== undefined) {
+                    // Default to dGPU tab if iGPU frequency is not available or is 0
+                    const hasUsableIGpuFreq = iGpuInfo.coreFrequency !== undefined && iGpuInfo.coreFrequency > 0;
+                    this.gpuMonitorTabIndex = hasUsableIGpuFreq ? 0 : 1;
+                    this.gpuMonitorTabIndexSet = true;
+                }
             })
         );
     }


### PR DESCRIPTION
I am only using the dGPU on my laptop. The iGPU always shows `-1`.

This PR makes it so we show the dGPU stats by default if we are in that case.