### PR TITLE
Prevent fd/memory leak caused by keyboard backlight sysfs watch feedback loop

### DIFF
--- a/src/common/classes/ConfigHandler.ts
+++ b/src/common/classes/ConfigHandler.ts
@@ -112,8 +112,46 @@ export class ConfigHandler {
         });
     }
 
+    private settingsWriteInFlight: boolean = false;
+    private settingsWritePending: ITccSettings | undefined;
+    private settingsWriteWaiters: Array<{ resolve: () => void; reject: (err: unknown) => void }> = [];
+
     public async writeSettingsAsync(settings: ITccSettings, filePath: string = this.pathSettings): Promise<void> {
-        await this.writeConfigAsync<ITccSettings>(settings, filePath, { mode: this.settingsFileMod });
+        if (filePath !== this.pathSettings) {
+            await this.writeConfigAsync<ITccSettings>(settings, filePath, { mode: this.settingsFileMod });
+            return;
+        }
+
+        this.settingsWritePending = settings;
+        const waiter: Promise<void> = new Promise<void>((resolve, reject) => {
+            this.settingsWriteWaiters.push({ resolve, reject });
+        });
+
+        if (!this.settingsWriteInFlight) {
+            this.settingsWriteInFlight = true;
+            void this.drainSettingsWrites(filePath);
+        }
+
+        await waiter;
+    }
+
+    private async drainSettingsWrites(filePath: string): Promise<void> {
+        try {
+            while (this.settingsWritePending !== undefined) {
+                const pending: ITccSettings = this.settingsWritePending;
+                this.settingsWritePending = undefined;
+                const waiters = this.settingsWriteWaiters;
+                this.settingsWriteWaiters = [];
+                try {
+                    await this.writeConfigAsync<ITccSettings>(pending, filePath, { mode: this.settingsFileMod });
+                    for (const w of waiters) w.resolve();
+                } catch (err: unknown) {
+                    for (const w of waiters) w.reject(err);
+                }
+            }
+        } finally {
+            this.settingsWriteInFlight = false;
+        }
     }
 
     private recursivelyFillObject(obj: object, defaultObj: object): boolean {

--- a/src/service-app/classes/DaemonWorker.ts
+++ b/src/service-app/classes/DaemonWorker.ts
@@ -33,6 +33,8 @@ export abstract class DaemonWorker {
     protected previousProfile: ITccProfile;
     protected activeProfile: ITccProfile;
 
+    private workInFlight: boolean = false;
+
     protected abstract onStart(): Promise<void>;
     protected abstract onWork(): Promise<void>;
     protected abstract onExit(): Promise<void>;
@@ -41,7 +43,15 @@ export abstract class DaemonWorker {
         await this.triggerWork(this.onStart);
     }
     public async work(): Promise<void> {
-        await this.triggerWork(this.onWork);
+        if (this.workInFlight) {
+            return;
+        }
+        this.workInFlight = true;
+        try {
+            await this.triggerWork(this.onWork);
+        } finally {
+            this.workInFlight = false;
+        }
     }
     public async exit(): Promise<void> {
         await this.triggerWork(this.onExit);

--- a/src/service-app/classes/KeyboardBacklightListener.ts
+++ b/src/service-app/classes/KeyboardBacklightListener.ts
@@ -42,6 +42,9 @@ export class KeyboardBacklightListener {
     protected sysDBusUPowerKbdBacklightInterface: dbus.ClientInterface = {} as dbus.ClientInterface;
     protected onStartRetryCount: number = 5;
 
+    private ledWatchInFlight: Map<number, boolean> = new Map();
+    private ledLastKnownColors: Map<number, string> = new Map();
+
     constructor(private tccd: TuxedoControlCenterDaemon) {
         this.init();
     }
@@ -163,45 +166,70 @@ export class KeyboardBacklightListener {
     }
 
     private async initSysFSListener(): Promise<void> {
-        if (this.keyboardBacklightCapabilities.maxRed !== undefined) {
-            for (let i: number = 0; i < this.ledsRGBZones?.length; ++i) {
-                if (this.ledsRGBZones[i]) {
-                    if (await fileOKAsync(`${this.ledsRGBZones[i]}/multi_intensity`)) {
-                        (function (i: number): void {
-                            fs.watch(
-                                `${this.ledsRGBZones[i]}/multi_intensity`,
-                                async function (): Promise<void> {
-                                    if (
-                                        !(await this.sysDBusUPowerProps.Get('org.freedesktop.UPower', 'LidIsClosed'))
-                                            .value
-                                    ) {
-                                        const keyboardBacklightStatesNew: Array<KeyboardBacklightStateInterface> =
-                                            this.tccd.settings.keyboardBacklightStates;
-                                        const colors: number[] = (
-                                            await fs.promises.readFile(`${this.ledsRGBZones[i]}/multi_intensity`)
-                                        )
-                                            .toString()
-                                            .split(' ')
-                                            .map(Number);
-                                        if (keyboardBacklightStatesNew?.[i] && colors) {
-                                            keyboardBacklightStatesNew[i].red = colors[0];
-                                            keyboardBacklightStatesNew[i].green = colors[1];
-                                            keyboardBacklightStatesNew[i].blue = colors[2];
-                                            this.setKeyboardBacklightStates(
-                                                keyboardBacklightStatesNew,
-                                                false,
-                                                true,
-                                                true,
-                                            );
-                                        }
-                                    }
-                                }.bind(this),
-                            );
-                        }).bind(this)(i);
-                    }
-                }
+        if (this.keyboardBacklightCapabilities.maxRed === undefined) return;
+
+        for (let i: number = 0; i < this.ledsRGBZones?.length; ++i) {
+            const ledPath: string | undefined = this.ledsRGBZones[i];
+            if (!ledPath) continue;
+            const multiIntensityPath: string = `${ledPath}/multi_intensity`;
+            if (!(await fileOKAsync(multiIntensityPath))) continue;
+
+            const zoneIndex: number = i;
+
+            try {
+                const initial: string = (await fs.promises.readFile(multiIntensityPath)).toString();
+                this.ledLastKnownColors.set(zoneIndex, this.normalizeColorTriple(initial));
+            } catch (_e: unknown) {
+                // ignore, will be populated on first real event
             }
+
+            fs.watch(multiIntensityPath, async (): Promise<void> => {
+                if (this.ledWatchInFlight.get(zoneIndex)) return;
+                this.ledWatchInFlight.set(zoneIndex, true);
+                try {
+                    if (
+                        (await this.sysDBusUPowerProps.Get('org.freedesktop.UPower', 'LidIsClosed')).value
+                    ) {
+                        return;
+                    }
+
+                    const raw: string = (await fs.promises.readFile(multiIntensityPath)).toString();
+                    const normalized: string = this.normalizeColorTriple(raw);
+                    const previous: string | undefined = this.ledLastKnownColors.get(zoneIndex);
+                    if (normalized === previous) {
+                        return;
+                    }
+                    this.ledLastKnownColors.set(zoneIndex, normalized);
+
+                    const colors: number[] = normalized.split(' ').map(Number);
+                    const keyboardBacklightStatesNew: Array<KeyboardBacklightStateInterface> =
+                        this.tccd.settings.keyboardBacklightStates;
+                    if (keyboardBacklightStatesNew?.[zoneIndex] && colors.length >= 3) {
+                        keyboardBacklightStatesNew[zoneIndex].red = colors[0];
+                        keyboardBacklightStatesNew[zoneIndex].green = colors[1];
+                        keyboardBacklightStatesNew[zoneIndex].blue = colors[2];
+                        await this.setKeyboardBacklightStates(
+                            keyboardBacklightStatesNew,
+                            false,
+                            true,
+                            true,
+                        );
+                    }
+                } catch (err: unknown) {
+                    console.error(`KeyboardBacklightListener: watch handler (${zoneIndex}) failed => ${err}`);
+                } finally {
+                    this.ledWatchInFlight.set(zoneIndex, false);
+                }
+            });
         }
+    }
+
+    private normalizeColorTriple(raw: string): string {
+        const parts: number[] = raw.trim().split(/\s+/).map(Number);
+        if (parts.length < 3 || parts.some((n: number): boolean => Number.isNaN(n))) {
+            return raw.trim();
+        }
+        return `${parts[0]} ${parts[1]} ${parts[2]}`;
     }
 
     // Input from TCC
@@ -363,6 +391,8 @@ export class KeyboardBacklightListener {
                             const red: string = keyboardBacklightStatesNew[i].red.toString();
                             const green: string = keyboardBacklightStatesNew[i].green.toString();
                             const blue: string = keyboardBacklightStatesNew[i].blue.toString();
+
+                            this.ledLastKnownColors.set(i, `${red} ${green} ${blue}`);
 
                             await fs.promises.appendFile(
                                 `${this.ledsRGBZones[i]}/multi_intensity`,


### PR DESCRIPTION
Fixes the crash described in issue #518 - `tccd` runs out of memory and exits when a profile switch is triggered while external software is concurrently writing to the per-key RGB LED `multi_intensity` sysfs files. Either condition on its own is harmless; both together trigger a runaway feedback loop.

A concrete reproducer is [tuxedo-rainbow-wave](https://github.com/T-vK/tuxedo-rainbow-wave), which animates the keyboard by writing to those sysfs nodes at high frequency. Starting the animation and then switching a profile via DBus causes RSS to grow at ~35-70 MiB/s until `tccd` crashes.

## Root cause

`KeyboardBacklightListener.initSysFSListener()` installs an `fs.watch` handler on every per-key LED `multi_intensity` sysfs file. The handler:

1. Reads the file back from sysfs.
2. Updates the in-memory `keyboardBacklightStates`.
3. Calls `setKeyboardBacklightStates()`, which writes the new colours back to all sysfs files **and** writes the full settings JSON to `/etc/tcc/settings`.

Step 3 writes to the very sysfs files being watched, which immediately fires new watch events. On a quiet system, the handler reads back the value it just wrote and the loop settles. However, a profile switch triggers a massive burst by writing to hundreds of LED zones simultaneously. If external software (e.g. tuxedo-rainbow-wave) is concurrently writing different colours to these files, each of those hundreds of handlers reads a divergent value, treats it as a new state, and triggers another full write cycle. This creates an exponential "thundering herd" of concurrent async chains that hold open file descriptors, JSON string buffers, libuv write requests, and DBus calls. These accumulate faster than they are resolved, eventually hitting the DBus pending-reply limit and crashing the process. Neither condition alone is sufficient to trigger the runaway.

A secondary contributor is that `DaemonWorker.work()` had no guard against concurrent invocations, so the periodic `setInterval` tick, DBus-triggered `triggerStateCheck()` calls, and fire-and-forget `onWork()` tail-calls in several `onStart()` implementations could all run simultaneously, each retaining its own async stack frame.

## Changes

### `src/service-app/classes/DaemonWorker.ts`

Added a `workInFlight` boolean guard to `work()`. If a worker's `work()` is already executing, subsequent calls return immediately rather than spawning a concurrent async frame.

### `src/service-app/classes/KeyboardBacklightListener.ts`

Refactored `initSysFSListener()`:

- **Per-LED in-flight guard** (`ledWatchInFlight`): drops watch events for a zone that is already being handled, preventing concurrent handler stacks per LED.
- **Last-known-value cache** (`ledLastKnownColors`): after reading the file, the normalized colour triple is compared against the previously seen value. If unchanged (i.e. the event echoes the daemon's own write), the handler returns immediately without touching settings or triggering further writes. This breaks the feedback loop.
- **Cache priming** in `setKeyboardBacklightStates`: before writing a colour to sysfs, the expected value is stored in `ledLastKnownColors`, so the resulting watch event is recognised as a no-op.
- Replaced the IIFE+`.bind(this)` closure pattern with a straightforward arrow function capturing `zoneIndex` directly.
- Added `normalizeColorTriple()` for consistent whitespace-insensitive string comparison.

### `src/common/classes/ConfigHandler.ts`

Replaced the trivial `writeSettingsAsync` (a direct pass-through to `writeConfigAsync`) with a coalescing single-flight writer:

- At most one `writeFile` to the settings path is in flight at a time.
- Further concurrent callers replace the pending payload and await the same flush, so a burst of N callers produces one write rather than N concurrent ones.
- For any non-default `filePath` argument the original direct-write behaviour is preserved.

## Verification

Tested with [tuxedo-rainbow-wave](https://github.com/T-vK/tuxedo-rainbow-wave) running continuously, followed by a profile switch via DBus, against both the unpatched and patched binary built from this repository.

### Before fix

| Time | RSS (MiB) | CPU (%) | Phase |
|------|----------:|--------:|-------|
| T+0:50 |   73.1 |  2.2 | tccd idle |
| T+0:55 |   73.1 |  2.0 | tccd idle |
| T+1:00 |  269.9 |  4.6 | rainbow-wave started |
| T+1:05 |  310.4 | 10.9 | |
| T+1:10 |  351.0 | 16.4 | |
| T+1:31 |  350.9 | 28.4 | |
| T+2:01 |  358.0 | 44.8 | profile switch triggered |
| T+2:06 |  450.6 | 46.4 | |
| T+2:21 |  562.8 | 51.5 | |
| T+2:52 |  839.6 | 60.4 | |
| T+3:12 |  970.6 | 65.1 | |
| T+3:27 | 1119.6 | 68.4 | |
| T+3:42 | 1276.5 | 71.6 | |
| T+3:47 | 1311.8 | 72.4 | (crash imminent) |

RSS grows at 35-70 MiB every 5 seconds without any sign of levelling off. The process eventually exhausts memory, hits the DBus pending-reply limit, and exits.

### After fix

| Time | RSS (MiB) | CPU (%) | Phase |
|------|----------:|--------:|-------|
| T+0:08 |  68.4 |  4.9 | tccd idle |
| T+0:23 |  70.5 |  2.9 | tccd idle |
| T+0:28 | 142.1 |  5.4 | rainbow-wave started |
| T+0:33 | 207.5 | 13.2 | |
| T+0:38 | 214.1 | 18.7 | |
| T+0:43 | 221.6 | 25.9 | plateau |
| T+0:54 | 221.6 | 28.2 | plateau |
| T+0:59 | 221.6 | 30.5 | plateau |
| T+1:04 | 225.2 | 31.5 | profile switch triggered |
| T+1:09 | 225.3 | 32.9 | |
| T+1:14 | 225.3 | 35.2 | |
| T+1:24 | 225.3 | 38.7 | |
| T+1:29 | 225.4 | 40.1 | stable |

RSS plateaus at ~222 MiB while rainbow-wave runs, then adds roughly 4 MiB on the profile switch and stays flat. No crash observed.

### Summary

| Metric | Before fix | After fix |
|--------|-----------|-----------|
| Open file descriptors (peak) | 1600+ | < 120 (transient, returns to ~25) |
| `/etc/tcc/settings` fds (steady state) | 500-600 | 0 |
| LED sysfs fds (steady state) | 600+ | 0 |
| RSS after profile switch | unbounded growth | stable ~225 MiB |
| Crash observed | Yes (DBus LimitsExceeded) | No |
