### PR TITLE
Bugfix/profile edit form stale validators

### DIFF
--- a/src/ng-app/app/profile-details-edit/profile-details-edit.component.ts
+++ b/src/ng-app/app/profile-details-edit/profile-details-edit.component.ts
@@ -107,12 +107,16 @@ export class ProfileDetailsEditComponent implements OnInit, OnDestroy {
             return;
         }
 
-        // Create form group from profile
-        if (this.profileFormGroup === undefined) {
+        // Create form group from profile. Rebuilt (not just reset) whenever the edited
+        // profile's identity changes, since validators/FormArray controls are wired to a
+        // specific profile's shape (e.g. odmPowerLimits.tdpValues length) and become stale
+        // if reused across profiles with a different shape.
+        if (this.profileFormGroup === undefined || this.viewProfile === undefined || this.currentProfileId !== profile.id) {
             this.profileFormGroup = this.createProfileFormGroup(profile);
         } else {
             this.profileFormGroup.reset(profile);
         }
+        this.currentProfileId = profile.id;
 
         if (this.selectStateControl === undefined) {
             this.selectStateControl = new FormControl(this.state.getProfileStates(this.viewProfile.id));
@@ -136,6 +140,7 @@ export class ProfileDetailsEditComponent implements OnInit, OnDestroy {
     public selectStateControl: FormControl;
     public profileFormGroup: FormGroup;
     public profileFormProgress: boolean = false;
+    private currentProfileId: string;
 
     private subscriptions: Subscription = new Subscription();
     private fansMinSpeedSubscription: Subscription = new Subscription();

--- a/src/ng-app/app/profile-details-edit/profile-details-edit.component.ts
+++ b/src/ng-app/app/profile-details-edit/profile-details-edit.component.ts
@@ -21,10 +21,10 @@ import { Component, EventEmitter, Input, type OnDestroy, type OnInit, Output, Vi
 // biome-ignore lint: injection token
 import {
     type AbstractControl,
-    type FormArray,
+    FormArray,
     FormBuilder,
     FormControl,
-    type FormGroup,
+    FormGroup,
     type ValidatorFn,
     Validators,
 } from '@angular/forms';
@@ -70,6 +70,23 @@ function maxControlValidator(comparisonControl: AbstractControl): ValidatorFn {
         }
         return errors;
     };
+}
+
+// Diagnostic helper: submitFormInput() silently no-ops when the form is invalid, with no
+// indication of which control caused it. Walks the control tree and returns "path: {errors}"
+// for every invalid leaf control, so that reason shows up in the console instead.
+function findInvalidControlPaths(control: AbstractControl, path: string = ''): string[] {
+    if (control instanceof FormGroup || control instanceof FormArray) {
+        const childPaths: string[] = [];
+        for (const key of Object.keys(control.controls)) {
+            childPaths.push(...findInvalidControlPaths(control.controls[key], path ? `${path}.${key}` : key));
+        }
+        return childPaths;
+    }
+    if (control.invalid) {
+        return [`${path}: ${JSON.stringify(control.errors)}`];
+    }
+    return [];
 }
 
 @Component({
@@ -434,6 +451,9 @@ export class ProfileDetailsEditComponent implements OnInit, OnDestroy {
                     this.utils.pageDisabled = false;
                 });
         } else {
+            console.error(
+                `ProfileDetailsEditComponent: submitFormInput: form invalid, not saving. Invalid controls: ${findInvalidControlPaths(this.profileFormGroup).join(', ')}`,
+            );
             this.profileFormProgress = false;
             this.utils.pageDisabled = false;
         }


### PR DESCRIPTION
## Steps to reproduce
- open default mobile custom profile (set as "battery" profile) in editor by clicking on it under "used profiles"
- open default custom profile (set as AC profile) in editor by clicking on it under "used profiles"
- change description or whatever setting
- save

\> the admin dialog doesn't show up, the form stays dirty, the profile is not saved

Expected: admin dialog shows up, the profile is saved

## What happens
Opening a profile listed under "used profiles" doesn't create profile edit form if it is already opened.
Also, TDP validators for maximum values are set to look at the value of the "next" control.
This means that control[0] has to be lower than control[1] value, by looking at **current** control[1] value.
So if we load a profile with 15, 25, 50, then load a profile with 45, 60, 110, when control[0] is set to 45, validator kicks in. As control[1] has not yet been updated to 60 and still is 25, control[0] is invalidated.
This bug does not happen when opening a profile with higher TDP values from the profiles menu because this menu "destroys" the profile edit form (sets no profileId), it only happens when loading a profile with higher TDP values from the "used profiles".

## The fix
Whenever the loaded profile is not the same one (different profile id), the profile edit form is created, starting with fresh validators on TDP values.

## Bonus
Adds dev tools logging on trying to save an invalid form to output the invalid controls. That might help debugging such situations.
Those logs show this for this bug:
```
 main-VFRZESWY.js:166403 ProfileDetailsEditComponent: submitFormInput: form invalid, not saving. Invalid controls: odmPowerLimits.tdpValues.0: {"max":25,"actual":45}, odmPowerLimits.tdpValues.1: {"max":50,"actual":60}
  submitFormInput @ main-VFRZESWY.js:166403
  ProfileDetailsEditComponent_mat_card_2_Template_button_click_8_listener @ main-VFRZESWY.js:165414
  executeListenerWithErrorHandling @ main-VFRZESWY.js:47259
  wrapListenerIn_markDirtyAndPreventDefault @ main-VFRZESWY.js:47246
  (anonymous) @ main-VFRZESWY.js:64051
  invokeTask @ polyfills-UOWBCZAN.js:428
  (anonymous) @ main-VFRZESWY.js:39912
  onInvokeTask @ main-VFRZESWY.js:39912
  invokeTask @ polyfills-UOWBCZAN.js:428
  onInvokeTask @ main-VFRZESWY.js:40052
  invokeTask @ polyfills-UOWBCZAN.js:428
  runTask @ polyfills-UOWBCZAN.js:209
  invokeTask @ polyfills-UOWBCZAN.js:505
  invokeTask @ polyfills-UOWBCZAN.js:1028
  globalCallback @ polyfills-UOWBCZAN.js:1049
  globalZoneAwareCallback @ polyfills-UOWBCZAN.js:1074
```

## Notes
Assisted by Claude Sonnet 5 to identify the source of the bug and apply a fix.
I've reviewed and tested it.
Also I tried to think of some other edge cases like loading a profile with more or less tdp values but it seems the number of tdp values is somehow fixed.